### PR TITLE
allow multiple networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 > - `block` target block to snapshot from (leave empty to the get latest block),  
 > - `withBalances` set to true to snapshot owner and their balances,  
 > - `tokenid` filter the tokenid to be snapshotted (for semi-fungible token standard). Leave it empty to omit filter.  
+> - `targetNetwork` the network you want, i.e. for ethereum mainnet put "ETH_MAINNET", for optimism mainnet put "OPT_MAINNET".  
 
 - Run `node index` to snapshot.  
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
-    "address": "0x6a46B8591679f53AE1AEd3Bae673F4D2208f7177",
+    "address": "0x5Af0D9827E0c53E4799BB226655A1de152A425a5",
     "block": "",
-    "withBalances": true,
-    "tokenid": "1"
+    "withBalances": false,
+    "tokenid": "",
+    "targetNetwork": "ETH_MAINNET"
 }

--- a/index.js
+++ b/index.js
@@ -9,16 +9,18 @@ dotenv.config();
 // Configure snapshot in config.json
 const snapshotConfig = JSON.parse(fs.readFileSync('config.json'));
 
-// Configure Alchemy key and chain.
-const settings = {
-    apiKey: process.env.ALCHEMY_KEY,
-    network: Network.ETH_MAINNET,
-};
 
 const address = snapshotConfig.address;
 const height = snapshotConfig.block; 
 const withBalances = snapshotConfig.withBalances;
 const idFilter = snapshotConfig.tokenid;
+const targetNetwork = snapshotConfig.targetNetwork;
+
+// Configure Alchemy key and chain.
+const settings = {
+    apiKey: process.env.ALCHEMY_KEY,
+    network: Network[targetNetwork],
+};
 
 const alchemy = new Alchemy(settings);
 
@@ -93,7 +95,7 @@ async function getOwners() {
     let result = [];
     let options = { method: 'GET', headers: {Accept: 'application/json'} };
     await oraPromise(
-            fetch(`https://eth-mainnet.g.alchemy.com/nft/v2/${settings.apiKey}/getOwnersForCollection?contractAddress=${address}&withTokenBalances=false&block=${height}`, options)
+            fetch(`https://${settings.network}.g.alchemy.com/nft/v2/${settings.apiKey}/getOwnersForCollection?contractAddress=${address}&withTokenBalances=false&block=${height}`, options)
             .then(response => response.json())
             .then(response => result = response.ownerAddresses)
             .catch(err => console.error(colors.red(err))),
@@ -118,7 +120,7 @@ async function getOwnersWithBalance() {
     let result = [];
     let options = { method: 'GET', headers: {Accept: 'application/json'} };
     await oraPromise(
-            fetch(`https://eth-mainnet.g.alchemy.com/nft/v2/${settings.apiKey}/getOwnersForCollection?contractAddress=${address}&withTokenBalances=true&block=${height}`, options)
+            fetch(`https://${settings.network}.g.alchemy.com/nft/v2/${settings.apiKey}/getOwnersForCollection?contractAddress=${address}&withTokenBalances=true&block=${height}`, options)
             .then(response => response.json())
             .then(response => result = response.ownerAddresses)
             .catch(err => console.error(colors.red(err))),


### PR DESCRIPTION
This tool was very useful for me (best of 4 snapshot tools I tried by far - for my purposes). Thank you for creating it. I needed to run a snapshot on Optimism, and needed to make some changes to accommodate. I then generalized those changes to apply to any Alchemy supported network, there is a new field in the config file for the target network.